### PR TITLE
feature: enable data explorer to activate when writing custom SQL

### DIFF
--- a/datasette_nteract_data_explorer/__init__.py
+++ b/datasette_nteract_data_explorer/__init__.py
@@ -24,8 +24,7 @@ def cached_filepaths_for_js_modules():
         ## Figure out support for older browsers once
         ## an MVP is working better.
         filesizes = [path.getsize(file) for file in glob.glob(pattern)]
-
-        print("pattern", pattern, files)
+        # print("pattern", pattern, files)
 
         smallestFileIndex = argmin(filesizes)
 
@@ -57,16 +56,25 @@ def cached_filepaths_for_extension(extension):
     return cache[pattern]
 
 
+# Create a set with table names that should activate the plugin
+# for the datasette UI.
+# Listing: https://docs.datasette.io/en/stable/custom_templates.html#custom-templates
+# database view is activated by writing custom SQL
+PERMITTED_VIEWS = {"table", "query", "database"}
+
+
 # These hooks only run
 # for the TABLE pages. Other view choices include
 # database, index, etc
 @hookimpl
 def extra_css_urls(view_name):
-    if view_name == "table":
+    # check if the view is in the set of permitted views
+    if view_name in PERMITTED_VIEWS:
         return cached_filepaths_for_extension("css")
 
 
 @hookimpl
 def extra_js_urls(view_name):
-    if view_name == "table":
+    print(view_name)
+    if view_name in PERMITTED_VIEWS:
         return cached_filepaths_for_js_modules()

--- a/frontend-src/main.tsx
+++ b/frontend-src/main.tsx
@@ -6,7 +6,9 @@ function onLoad() {
   let mountElement: HTMLElement | null = null;
   let jsonUrl: string | null = null;
 
-  const jsonEl = document.querySelector(".export-links a[href*=json]");
+  const jsonEl = document.querySelector(
+    'link[type="application/json+datasette"]'
+  );
 
   if (jsonEl) {
     jsonUrl = jsonEl.getAttribute("href");
@@ -18,6 +20,7 @@ function onLoad() {
   }
 
   if (jsonUrl) {
+    // reshape URL to include another query parameter
     jsonUrl += jsonUrl.indexOf("?") > -1 ? "&" : "?";
     jsonUrl += "_shape=array";
 

--- a/frontend-src/main.tsx
+++ b/frontend-src/main.tsx
@@ -7,7 +7,11 @@ function onLoad() {
   let jsonUrl: string | null = null;
 
   const jsonEl = document.querySelector(
-    'link[type="application/json+datasette"]'
+    // This is available only after datasette version 61.1
+    // Remove this once plugin can specify which version of
+    // datasette it requires for correct operation.
+    // 'link[type="application/json+datasette"]'
+    '.export-links a[href*=json]'
   );
 
   if (jsonEl) {


### PR DESCRIPTION
## Motivation

- Fixes #2 . Note that writing custom sql can trigger a database OR a query view, per the custom templates [docs](https://docs.datasette.io/en/stable/custom_templates.html#custom-templates).

## Changes

- Tested a fix for #3 that doesn't work for older versions of datasette, reverted it with notes intact
- Activate plugin for additional data views

## Testing

- Tested it works with a custom groupBy query: https://a.cl.ly/2Nuzpr9k using Dan Nguyen's Public Affairs Data Journalism test simplefolks dataset: http://2016.padjo.org/tutorials/sqlite-data-starterpacks/#more-info-simplefolks-for-simple-sql