### PR TITLE
feature: synchronize graph state to URL parameters, enabling permalinking + sharing graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build
 .parcel-cache
 node_modules/
 datasette_nteract_data_explorer/static/
+
+# Build results for JS
+js-dist/

--- a/frontend-src/DatasetteDataExplorer.tsx
+++ b/frontend-src/DatasetteDataExplorer.tsx
@@ -11,6 +11,9 @@ import {
 
 import DataExplorer from "@nteract/data-explorer";
 import localforage from "localforage";
+import { atomWithHash } from "jotai/utils";
+import { useAtom } from "jotai";
+
 import { dataFrameToFrictionlessSpec } from "./datasette-data-explorer-helpers";
 import {
   FrictionlessSpecField,
@@ -22,12 +25,17 @@ interface DatasetteDataExplorerProps {
   dataUrl: string;
 }
 
+export const explorerMetadataAtom = atomWithHash("dataExplorer.metadata", { dx: {}});
+
+
 export const DatasetteDataExplorer: FunctionComponent<
   DatasetteDataExplorerProps
 > = (props) => {
   const { dataUrl } = props;
   const [frictionlessData, setFrictionlessData] = useState<FrictionlessSpec>();
   const [customFields, setCustomFields] = useState<FrictionlessSpecField[]>();
+
+  const [explorerMetadata, setExplorerMetadata ] = useAtom(explorerMetadataAtom);
 
   // is settings visibile
   const [isSettingsVisible, setIsSettingsVisible] = useState(false);
@@ -100,7 +108,11 @@ export const DatasetteDataExplorer: FunctionComponent<
             </AccordionTrigger>
             <AccordionContent>
               <div style={{ marginBottom: 20 }}>
-                <DataExplorer data={combinedData} />
+                <DataExplorer
+                  data={combinedData}
+                  metadata={explorerMetadata}
+                  onMetadataChange={setExplorerMetadata}
+                />
                 <div>
                   <Button
                     onClick={() => {
@@ -108,7 +120,7 @@ export const DatasetteDataExplorer: FunctionComponent<
                     }}
                     style={{ marginTop: 4, marginBottom: 4 }}
                   >
-                    {isSettingsVisible ? 'Hide' : "Show"} Data Explorer Settings
+                    {isSettingsVisible ? "Hide" : "Show"} Data Explorer Settings
                   </Button>
 
                   {isSettingsVisible && (

--- a/frontend-src/index.html
+++ b/frontend-src/index.html
@@ -2,10 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <title>Datasette Nteract Data Explorer</title>
+    <title>Datasette Nteract Data Explorer Demo</title>
   </head>
       <script type='module' src="main.tsx"></script>
   <body>
     <div id="root"></div>
+    <p class="export-links">This data as <a href="https://datasette-nteract-data-explorer.vercel.app/happy_planet_index.json?sql=select%20*%20from%20hpi_cleaned">json</a></p>
+    <table class="rows-and-columns"></table>
   </body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@modulz/design-system": "^0.6.2",
     "@nteract/data-explorer": "^8.2.12",
     "@swc/helpers": "^0.3.8",
+    "jotai": "^1.7.8",
     "localforage": "^1.10.0",
     "preact": "^10.6.6",
     "styled-components": "^5.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,11 @@ is-json@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-json/-/is-json-2.0.1.tgz#6be166d144828a131d686891b983df62c39491ff"
   integrity sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=
 
+jotai@^1.7.8:
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.7.8.tgz#1ac4daa2731e0f8e7fab8abb96aebf94b9dfc1a3"
+  integrity sha512-rXwWz6uLqyZUCRzWIPiYTjI1hjskVxVpDN3lBoOHi66z6uQFkFmKwR8YhcQd+Ex4lODlReuKNIx6WwsF9aKy3g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## Motivation

- Suggestion from @casidiablo in #18 to make sharing graphs easier
- Testing Jotai as a way to cheaply implement URL state syncing without using Redux or `query-state` packages

## Changes

- Syncs graph state as a URL Hash ( everything behind `#`). As a side effect, this also stores graph browsing history in browser history (so forward/backward will act as undo/redo).
- Updates the demo environment to have the necessary HTML for the plugin to mount appropriately
- Adds `jotai` as dependency

## Notes

- Note the SQL query is already saved as a URL parameter as part of native datasette, so we only need to add the graph configuration part
- On URL hash vs Query parameters (TODO: this can feed into expanding my internal blog post)
  - Query parameters have the benefit of being namespaced, making it easier to avoid colliding with the state used by other plugins. Sadly, they are sent to the server. The server doesn't need to know about this config, this is only ever processed by the frontend plugin. 
  - A downside of using a URL hash: the URL hash may interfere with other plugins that also use hashes, like the Vega plugin, since hashes (unlike query strings) may be overwritten. If this becomes an issue, we can invest in a solution where we determine a data structure strategy for all plugins that share the URL hash. Then, each plugin should only parse/modify properties that it's "allowed" to, and leaves the others intact. We are not there yet.
 
- On keeping the hash small
  - The default DX object is bigger than is strictly necessary. However, it adds to engineering complexity to strip out properties whose values are equal to the defaults + hydrate appropriately.
- Referenced this blog post: https://betterprogramming.pub/how-and-why-you-should-store-react-ui-state-in-the-url-f2013a204cb2