### PR TITLE
feat: proof of concept initialization hook for instantiating JS plugins in datasette-lite

### DIFF
--- a/frontend-src/main.tsx
+++ b/frontend-src/main.tsx
@@ -1,8 +1,9 @@
 import { render, h } from "preact";
 
-document.addEventListener("DOMContentLoaded", onLoad);
 
 function onLoad() {
+  console.log("datasette-plugins: Registering datasette-nteract-data-explorer");
+
   let mountElement: HTMLElement | null = null;
   let jsonUrl: string | null = null;
 
@@ -39,4 +40,12 @@ function onLoad() {
       }
     });
   }
+}
+
+// Register listeners
+document.addEventListener("DOMContentLoaded", onLoad);
+
+// Prototype: enable dispatch via a web CustomEvent as an alternative
+if ((window as any).__IS_DATASETTE_LITE__) {
+  document.addEventListener("DatasetteLiteScriptsLoaded", onLoad);
 }


### PR DESCRIPTION
## Motivation

- https://github.com/simonw/datasette-lite/issues/8

## Changes

- Allow [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) to activate this plugin, since the DOM has loaded by the time this script tag gets to be included.
- Avoid double initialization dispatch by making sure the parent page sets a global first.

## Testing

- Will update this issue with links after publishing the new release to PyPI to see if this works.