### PR TITLE
feat: disable URL state sync feature when running in datasette-lite

### DIFF
--- a/frontend-src/DatasetteDataExplorer.tsx
+++ b/frontend-src/DatasetteDataExplorer.tsx
@@ -23,15 +23,16 @@ import { FieldTypeCustomizerPanel } from "./FieldTypeCustomizer";
 
 interface DatasetteDataExplorerProps {
   dataUrl: string;
+  /** When true, synchronizes cmponent state to URL hash */
+  shouldSyncStateToUrlHash?: boolean;
 }
 
 export const explorerMetadataAtom = atomWithHash("dataExplorer.metadata", { dx: {}});
 
-
 export const DatasetteDataExplorer: FunctionComponent<
   DatasetteDataExplorerProps
 > = (props) => {
-  const { dataUrl } = props;
+  const { dataUrl, shouldSyncStateToUrlHash } = props;
   const [frictionlessData, setFrictionlessData] = useState<FrictionlessSpec>();
   const [customFields, setCustomFields] = useState<FrictionlessSpecField[]>();
 
@@ -110,8 +111,8 @@ export const DatasetteDataExplorer: FunctionComponent<
               <div style={{ marginBottom: 20 }}>
                 <DataExplorer
                   data={combinedData}
-                  metadata={explorerMetadata}
-                  onMetadataChange={setExplorerMetadata}
+                  metadata={shouldSyncStateToUrlHash ? explorerMetadata : undefined}
+                  onMetadataChange={shouldSyncStateToUrlHash ? setExplorerMetadata : undefined}
                 />
                 <div>
                   <Button

--- a/frontend-src/main.tsx
+++ b/frontend-src/main.tsx
@@ -1,5 +1,8 @@
 import { render, h } from "preact";
 
+// Modify some behaviors when running as a pluging called by Datasette from a webassembly environment
+// This is a temporary measure until we the Datasette Plugin API can indicate the host environment in a more direct way.
+const IS_DATASETTE_LITE = !Boolean((window as any).__IS_DATASETTE_LITE__);
 
 function onLoad() {
   console.log("datasette-plugins: Registering datasette-nteract-data-explorer");
@@ -34,7 +37,13 @@ function onLoad() {
       DatasetteDataExplorer,
     }) {
       if (mountElement && jsonUrl) {
-        render(<DatasetteDataExplorer dataUrl={jsonUrl} />, mountElement);
+        render(
+          <DatasetteDataExplorer
+            dataUrl={jsonUrl}
+            shouldSyncStateToUrlHash={!IS_DATASETTE_LITE}
+          />,
+          mountElement
+        );
       } else {
         console.log("Couldn't find mount point");
       }
@@ -46,6 +55,6 @@ function onLoad() {
 document.addEventListener("DOMContentLoaded", onLoad);
 
 // Prototype: enable dispatch via a web CustomEvent as an alternative
-if ((window as any).__IS_DATASETTE_LITE__) {
+if (IS_DATASETTE_LITE) {
   document.addEventListener("DatasetteLiteScriptsLoaded", onLoad);
 }


### PR DESCRIPTION
## Motivation

- Currently, users break their shareable links when using this plugin inside of datasette lite since the plugin and the host application are both trying to store information in URL state. This shareable links feature is only intended to be used when not in the datasette lite environment.
- This is a partial fix for https://github.com/hydrosquall/datasette-nteract-data-explorer/issues/29 
  - (Full fix would also require a fix upstream to change the behavior of the buttons for applying filters).

## Changes

- Add a prop that can control whether app state is stored in the URL hash, and toggle its value based on whether the datasette lite global is on the window.

## Testing

- Tested in the local sandbox with

    yarn run dev

Confirmed that after toggling the value of the global boolean, state would either be autosync'd to URL hash, or ignored. Component continued to work when state was maintained internally.