### PR TITLE
fix: reverse inverted boolean for datasette membership test

### DIFF
--- a/frontend-src/main.tsx
+++ b/frontend-src/main.tsx
@@ -2,7 +2,7 @@ import { render, h } from "preact";
 
 // Modify some behaviors when running as a pluging called by Datasette from a webassembly environment
 // This is a temporary measure until we the Datasette Plugin API can indicate the host environment in a more direct way.
-const IS_DATASETTE_LITE = !Boolean((window as any).__IS_DATASETTE_LITE__);
+const IS_DATASETTE_LITE = Boolean((window as any).__IS_DATASETTE_LITE__);
 
 function onLoad() {
   console.log("datasette-plugins: Registering datasette-nteract-data-explorer");


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of the `datasette-nteract-data-explorer` ecosystem! -->
## Motivation

- In #30 , the boolean test was reversed during testing

## Changes

- Remove the test `!` operator

## Testing

- Retested locally.