### PR TITLE
chore: bump version 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasette-nteract-data-explorer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Automatic data visualization in datasette",
   "source": "frontend-src/main.tsx",
   "main": "dist/index.js",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import os
 
-VERSION = "0.5.0"
+VERSION = "0.5.1"
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
 def get_long_description():


### PR DESCRIPTION
## Motivation

- Version bump to add the latest releases from today to PyPI, per guidance from docs
  - https://github.com/hydrosquall/datasette-nteract-data-explorer/blob/main/docs/CONTRIBUTING.md#releasing-new-versions